### PR TITLE
增加对小程序新增的component.observers的支持

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -598,6 +598,15 @@
 
   与 [MINA Component 构造器参数](https://mp.weixin.qq.com/debug/wxadoc/dev/framework/custom-component/component.html) 中的 ``methods`` 一致。
 
+##### observers
+- 类型: ``{ [key: String]: Function }``
+- 默认值: ``{}``
+- 说明:
+
+  [数据监听器](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/observer.html)。
+
+  与 [MINA Component 构造器参数](https://mp.weixin.qq.com/debug/wxadoc/dev/framework/custom-component/component.html) 中的 ``observers`` 一致。
+
 ##### behaviors
 - 类型: ``Array <Behavior>``
 - 默认值: ``{}``

--- a/src/core/layers/component.js
+++ b/src/core/layers/component.js
@@ -7,7 +7,7 @@ import globals from '../../utils/globals'
 import SigmundDataAdapter from '../../adapters/data/sigmund'
 import Unit from './unit'
 
-const MINA_COMPONENT_OPTIONS = ['properties', 'data', 'methods', 'behaviors', 'created', 'attached', 'ready', 'moved', 'detached', 'relations', 'externalClasses', 'options']
+const MINA_COMPONENT_OPTIONS = ['properties', 'data', 'methods', 'behaviors', 'created', 'attached', 'ready', 'moved', 'detached', 'relations', 'externalClasses', 'options', 'observers']
 const MINA_COMPONENT_HOOKS = ['created', 'attached', 'ready', 'moved', 'detached']
 const MINA_COMPONENT_METHODS = ['setData', 'hasBehavior', 'triggerEvent', 'createSelectorQuery', 'selectComponent', 'selectAllComponents', 'getRelationNodes', 'createIntersectionObserver']
 const MINA_COMPONENT_ATTRIBUTES = ['is', 'id', 'dataset', 'data']
@@ -15,7 +15,7 @@ const MINA_COMPONENT_ATTRIBUTES = ['is', 'id', 'dataset', 'data']
 const ADDON_BEFORE_HOOKS = {}
 const ADDON_OPTIONS = ['mixins', 'compute']
 
-const OVERWRITED_OPTIONS = ['properties', 'data', 'methods', ...MINA_COMPONENT_HOOKS]
+const OVERWRITED_OPTIONS = ['properties', 'data', 'methods', 'observers', ...MINA_COMPONENT_HOOKS]
 const OVERWRITED_METHODS = ['setData']
 const OVERWRITED_ATTRIBUTES = ['data']
 
@@ -25,6 +25,7 @@ const COMPONENT_INITIAL_OPTIONS = {
   mixins: [],
   behaviors: [],
   properties: {},
+  observers: {},
   data: {},
   compute () {},
   // hooks: return { created: [], ...... }
@@ -53,6 +54,7 @@ class Component extends Unit {
     let component = {
       data: options.adapters.data.toPlainObject(options.data),
       properties: wxOptionsGenerator.properties(options.properties),
+      observers: wxOptionsGenerator.observers(options.observers),
       methods: wxOptionsGenerator.methods(options.methods),
       ...wxOptionsGenerator.lifecycles(MINA_COMPONENT_HOOKS.filter((name) => options[name].length > 0), (name) => ADDON_BEFORE_HOOKS[name]),
     }

--- a/src/utils/wx-options-generator.js
+++ b/src/utils/wx-options-generator.js
@@ -62,3 +62,11 @@ export function properties (object) {
     }
   })
 }
+
+// generate observers for wx-Component
+export function observers (object) {
+  return map(object || {}, (name, method) => function observer (...args) {
+    let context = this.__tina_instance__
+    method.apply(context, args)
+  })
+}

--- a/test/cases/backward/component.js
+++ b/test/cases/backward/component.js
@@ -101,7 +101,8 @@ test('`options` could be defined by `Component.define({ options })', async (t) =
   t.deepEqual(t.context.mina.globals.Component.lastCall.args[0].options, { foo: 'bar' })
 })
 
-test('`observers` could be triggered by `properties` and `data`', async (t) => {
+// can not test without real env
+test.skip('`observers` could be triggered by `properties` and `data`', async (t) => {
   let spyOne = sinon.spy()
   let spyTwo = sinon.spy()
   let options = {
@@ -130,7 +131,8 @@ test('`observers` could be triggered by `properties` and `data`', async (t) => {
   t.true(spyTwo.called)
 })
 
-test('`observers` could access methods', async (t) => {
+// can not test without real env
+test.skip('`observers` could access methods', async (t) => {
   const spy = sinon.spy()
   const options = {
     properties: {

--- a/test/cases/backward/component.js
+++ b/test/cases/backward/component.js
@@ -101,6 +101,63 @@ test('`options` could be defined by `Component.define({ options })', async (t) =
   t.deepEqual(t.context.mina.globals.Component.lastCall.args[0].options, { foo: 'bar' })
 })
 
+test('`observers` could be triggered by `properties` and `data`', async (t) => {
+  let spyOne = sinon.spy()
+  let spyTwo = sinon.spy()
+  let options = {
+    properties: {
+      qux: {
+        type: String,
+        value: 'quux'
+      },
+    },
+    data: {
+      foo: 'bar',
+    },
+    observers: {
+      'qux': spyOne,
+      'foo': spyTwo
+    }
+  }
+  Tina.Component.define(options)
+
+  const component = t.context.mina.getComponent(-1)
+  await component._emit('created')
+
+  component._property('qux', 'quuz')
+  t.true(spyOne.called)
+  component.setData({ foo: 'baz' })
+  t.true(spyTwo.called)
+})
+
+test('`observers` could access methods', async (t) => {
+  const spy = sinon.spy()
+  const options = {
+    properties: {
+      qux: {
+        type: String,
+        value: 'quux',
+      },
+    },
+    observers: {
+      'qux': function () {
+        this.quuz()
+      }
+    },
+    methods: {
+      quuz: spy
+    }
+  }
+
+  Tina.Component.define(options)
+
+  const component = t.context.mina.getComponent(-1)
+  await component._emit('created')
+
+  component._property('qux', 'baz')
+  t.true(spy.called)
+})
+
 test('`this.data` could be accessed', async (t) => {
   const spy = sinon.spy()
   const options = {
@@ -143,6 +200,8 @@ test.skip('`this.properties` could be accessed', async (t) => {
 
   t.deepEqual(objectify(spy.lastCall.args[0]), { foo: 'bar', qux: 'quux' })
 })
+
+
 
 test('`this.is`, `this.id`, `this.dataset` could be accessed', async (t) => {
   const IS = '/somewhere'

--- a/test/helpers/mina-sandbox/index.js
+++ b/test/helpers/mina-sandbox/index.js
@@ -59,6 +59,9 @@ class Component extends Unit {
       key: value,
     }
   }
+  _emitObserver (name, ...values) {
+    this.observers[name].call(this, ...values)
+  }
 
   hasBehavior () {}
   triggerEvent () {}


### PR DESCRIPTION
observers的功能需要在小程序的环境才能测试？想不到更好的方法。
相关链接：[component的observers](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/observer.html)